### PR TITLE
Fix the Github Actions workflow 

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -24,7 +24,9 @@ jobs:
             otp_version: '20.3.8'
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+    - name: Install system dependencies
+      run: sudo apt-get -y update && sudo apt-get install -y libncurses5
     - name: Set up Elixir ${{ matrix.elixir_version }} on OTP ${{ matrix.otp_version }}
       uses: actions/setup-elixir@v1
       with:

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -24,7 +24,7 @@ jobs:
             otp_version: '20.3.8'
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4.1.1
     - name: Install system dependencies
       run: sudo apt-get -y update && sudo apt-get install -y libncurses5
     - name: Set up Elixir ${{ matrix.elixir_version }} on OTP ${{ matrix.otp_version }}


### PR DESCRIPTION
## Changes:

### Install `libncurses5` system library

This is required to fix the Elixir installation

### Update the actions/checkout version

See the release notes https://github.com/actions/checkout/releases.
The current version is very old. Newer versions contain more improvements and patches.
