### PR TITLE
fix broken links and remove dead img

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,10 @@ Elixir [Prometheus.io](https://prometheus.io) client based on [Prometheus.erl](h
 
 Starting from v3.0.0 works with Elixir >=1.6 and Erlang >=20. For older versions, please use older tags.
 
-![@skosch dashboard](https://aldusleaf.org/assets/images/2016/09/grafana.jpg)
-
 Dashboard from [Monitoring Elixir apps in 2016: Prometheus and Grafana](https://aldusleaf.org/monitoring-elixir-apps-in-2016-prometheus-and-grafana) by [**@skosch**](https://github.com/skosch).
 
  - IRC: #elixir-lang on Freenode;
- - [Slack](https://elixir-slackin.herokuapp.com/): #prometheus channel - [Browser](https://elixir-lang.slack.com/messages/prometheus) or App(slack://elixir-lang.slack.com/messages/prometheus).
+ - [Slack](https://elixir-slackin.herokuapp.com/): #prometheus channel - [Browser](https://elixir-lang.slack.com/messages/prometheus) or [App](slack://elixir-lang.slack.com/messages/prometheus).
 
 ## Example
 

--- a/lib/prometheus.ex
+++ b/lib/prometheus.ex
@@ -65,7 +65,7 @@ defmodule Prometheus do
   if it isn't.
 
   Both `new/1` and `declare/1` accept options as
-  [Keyword](http://elixir-lang.org/docs/stable/elixir/Keyword.html).
+  [Keyword](https://hexdocs.pm/elixir/Keyword.html).
   Common options are:
 
    - name - metric name, can be an atom or a string (required);


### PR DESCRIPTION
- The link to the Keyword elixir doc has been fixed.
- Fixed link to slack.
- Link to the img is deleted because it does not exist anymore.